### PR TITLE
Fix placeholder assumptions about twisted's logger

### DIFF
--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -47,7 +47,7 @@ class BaseApiTest(object):
 
     def test_request_email_code(self):
         body = self.api.request_email_code("fakeemail1@nowhere.test", "sekrit", 1)
-        log.msg("Got response %r", body)
+        log.msg("Got response %r" % body)
         self.assertIn("sid", body)
         self.mailSink.get_mail()
 
@@ -132,7 +132,7 @@ class BaseApiTest(object):
             self.assertTrue(is_valid_body["valid"])
 
         mail = self.mailSink.get_mail()
-        log.msg("Got email (invite): %r", mail)
+        log.msg("Got email (invite): %r" % mail)
         mail_object = json.loads(mail["data"])
         self.assertEquals(mail_object["token"], body["token"])
         self.assertEquals(mail_object["room_alias"], "#alias:fake.test")

--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -47,7 +47,7 @@ class BaseApiTest(object):
 
     def test_request_email_code(self):
         body = self.api.request_email_code("fakeemail1@nowhere.test", "sekrit", 1)
-        log.msg("Got response %r" % body)
+        log.msg("Got response %r" % (body,))
         self.assertIn("sid", body)
         self.mailSink.get_mail()
 
@@ -132,7 +132,7 @@ class BaseApiTest(object):
             self.assertTrue(is_valid_body["valid"])
 
         mail = self.mailSink.get_mail()
-        log.msg("Got email (invite): %r" % mail)
+        log.msg("Got email (invite): %r" % (mail,))
         mail_object = json.loads(mail["data"])
         self.assertEquals(mail_object["token"], body["token"])
         self.assertEquals(mail_object["room_alias"], "#alias:fake.test")

--- a/matrix_is_tester/is_api.py
+++ b/matrix_is_tester/is_api.py
@@ -68,7 +68,7 @@ class IsApi(object):
     def get_token_from_mail(self):
         mail = self.mail_sink.get_mail()
 
-        log.msg("Got email: %r", mail)
+        log.msg("Got email: %r" % mail)
         if "data" not in mail:
             raise Exception("Mail has no 'data'")
         matches = re.match(r"<<<(.*)>>>", mail["data"])
@@ -114,7 +114,7 @@ class IsApi(object):
             headers=self.headers,
         )
         body = resp.json()
-        log.msg("submitToken returned %r", body)
+        log.msg("submitToken returned %r" % body)
         if not body["success"]:
             raise Exception("Submit token failed")
         return {"sid": sid, "client_secret": client_secret}

--- a/matrix_is_tester/is_api.py
+++ b/matrix_is_tester/is_api.py
@@ -68,7 +68,7 @@ class IsApi(object):
     def get_token_from_mail(self):
         mail = self.mail_sink.get_mail()
 
-        log.msg("Got email: %r" % mail)
+        log.msg("Got email: %r" % (mail,))
         if "data" not in mail:
             raise Exception("Mail has no 'data'")
         matches = re.match(r"<<<(.*)>>>", mail["data"])
@@ -114,7 +114,7 @@ class IsApi(object):
             headers=self.headers,
         )
         body = resp.json()
-        log.msg("submitToken returned %r" % body)
+        log.msg("submitToken returned %r" % (body,))
         if not body["success"]:
             raise Exception("Submit token failed")
         return {"sid": sid, "client_secret": client_secret}


### PR DESCRIPTION
Twisted's legacy logger (which is in use in the repo as it works well with `trial` testing out of the box) doesn't automatically process `%` placeholders and replace them with later function arguments.

Replace each of the lines that attempt to do this with a bog-standard percent replacement.