### PR TITLE
Mention that matrix-is-tester requires Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ matrix-is-tester
 ================
 
 matrix-is-tester is an integration testing system for Matrix Identity servers, similar
-to sytest (although using python rather than perl).
+to sytest (although using python rather than perl). It is written in Python 2.
 
 To launch the IS server, it attempts to import
 `matrix_is_test.launcher.MatrixIsTestLauncher`. This must be provided separately


### PR DESCRIPTION
Or else people will be confused.

Now they'll just be angry instead :^)