### PR TITLE
Port matrix-is-tester to Python 3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - "echo '+++ Lint'"
       - "flake8 matrix_is_tester"
       - "echo '+++ isort'"
-      - "isort -rc -c -vb matrix_is_tester"
+      - "isort -c -df -sp setup.cfg -rc matrix_is_tester"
       - "echo '+++ black'"
       - "python -m black --check --diff ."
     label: "Lint"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+
+# Twisted testing directory
+_trial_temp
+
+# Local dev resources
+.idea

--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -18,14 +18,14 @@
 
 import json
 
+from matrix_is_tester.is_api import IsApi
+from matrix_is_tester.launch_is import get_or_launch_is
+from matrix_is_tester.mailsink import get_shared_mailsink
+
 # These are standard python unit tests, but are generally intended
 # to be run with trial. Trial doesn't capture logging nicely if you
 # use python 'logging': it only works if you use Twisted's own.
 from twisted.python import log
-
-from matrix_is_tester.is_api import IsApi
-from matrix_is_tester.launch_is import get_or_launch_is
-from matrix_is_tester.mailsink import get_shared_mailsink
 
 
 class BaseApiTest(object):

--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -69,7 +69,7 @@ class BaseApiTest(object):
         token = self.api.get_token_from_mail()
 
         body = self.api.submit_email_token_via_get(sid, "verysekrit", token)
-        self.assertEquals(body, "matrix_is_tester:email_submit_get_response\n")
+        self.assertEquals(body, b"matrix_is_tester:email_submit_get_response\n")
 
         body = self.api.get_validated_threepid(sid, "verysekrit")
 

--- a/matrix_is_tester/fakehs.py
+++ b/matrix_is_tester/fakehs.py
@@ -16,13 +16,14 @@
 
 import atexit
 import base64
-import http.server
 import json
 import os
 import random
 import ssl
-import urllib.parse
+from six.moves import urllib
 from multiprocessing import Process
+
+from six.moves import BaseHTTPServer
 
 shared_fake_hs = None
 
@@ -61,7 +62,7 @@ def _destroy_shared():
     shared_fake_hs.tearDown()
 
 
-class _FakeHomeserverRequestHandler(http.server.BaseHTTPRequestHandler):
+class _FakeHomeserverRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path.startswith("/_matrix/federation/v1/openid/userinfo"):
             parsed = urllib.parse.urlparse(self.path)
@@ -104,7 +105,7 @@ class _FakeHomeserverRequestHandler(http.server.BaseHTTPRequestHandler):
 def _run_http_server():
     cert_file = os.path.join(os.path.dirname(__file__), "fakehs.pem")
 
-    httpd = http.server.HTTPServer(("localhost", 4490), _FakeHomeserverRequestHandler)
+    httpd = BaseHTTPServer.HTTPServer(("localhost", 4490), _FakeHomeserverRequestHandler)
     httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert_file, server_side=True)
     httpd.serve_forever()
 

--- a/matrix_is_tester/fakehs.py
+++ b/matrix_is_tester/fakehs.py
@@ -20,10 +20,9 @@ import json
 import os
 import random
 import ssl
-from six.moves import urllib
 from multiprocessing import Process
 
-from six.moves import BaseHTTPServer
+from six.moves import BaseHTTPServer, urllib
 
 shared_fake_hs = None
 

--- a/matrix_is_tester/fakehs.py
+++ b/matrix_is_tester/fakehs.py
@@ -104,7 +104,9 @@ class _FakeHomeserverRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 def _run_http_server():
     cert_file = os.path.join(os.path.dirname(__file__), "fakehs.pem")
 
-    httpd = BaseHTTPServer.HTTPServer(("localhost", 4490), _FakeHomeserverRequestHandler)
+    httpd = BaseHTTPServer.HTTPServer(
+        ("localhost", 4490), _FakeHomeserverRequestHandler
+    )
     httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert_file, server_side=True)
     httpd.serve_forever()
 

--- a/matrix_is_tester/is_api.py
+++ b/matrix_is_tester/is_api.py
@@ -71,7 +71,7 @@ class IsApi(object):
         log.msg("Got email: %r", mail)
         if "data" not in mail:
             raise Exception("Mail has no 'data'")
-        matches = re.match(r"<<<(.*)>>>", mail["data"])
+        matches = re.match(r"<<<(.*)>>>", mail["data"].decode("UTF-8"))
         if not matches.group(1):
             raise Exception("Failed to match token from mail")
 

--- a/matrix_is_tester/is_api.py
+++ b/matrix_is_tester/is_api.py
@@ -21,9 +21,9 @@ import re
 import string
 
 import requests
-from twisted.python import log
-
 from matrix_is_tester.fakehs import token_for_random_user
+
+from twisted.python import log
 
 
 class IsApi(object):

--- a/matrix_is_tester/mailsink.py
+++ b/matrix_is_tester/mailsink.py
@@ -41,7 +41,7 @@ class MailSinkSmtpServer(smtpd.SMTPServer):
         smtpd.SMTPServer.__init__(self, localaddr, remoteaddr)
         self.queue = q
 
-    def process_message(self, peer, mailfrom, rctpto, data):
+    def process_message(self, peer, mailfrom, rctpto, data, **kwargs):
         self.queue.put(
             {"peer": peer, "mailfrom": mailfrom, "rctpto": rctpto, "data": data}
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,15 @@
 [flake8]
 max-line-length = 90
+
+[isort]
+line_length = 88
+not_skip = __init__.py
+sections=FUTURE,STDLIB,COMPAT,THIRDPARTY,TWISTED,FIRSTPARTY,TESTS,LOCALFOLDER
+default_section=THIRDPARTY
+known_first_party = sydent
+known_tests=tests
+known_compat = mock,six
+known_twisted=twisted,OpenSSL
+multi_line_output=3
+include_trailing_comma=true
+combine_as_imports=true

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=["matrix_is_tester"],
     description="Black-box integration testing for Matrix Identity Servers",
     long_description=open("README.md").read(),
-    install_requires=["Twisted>=19.2.1", "requests>=2.22.0"],
+    install_requires=["Twisted>=19.2.1", "requests>=2.22.0", "six>=1.13.0"],
     extras_require={"lint": ["flake8>=3.7.8", "isort>=4.3.21", "black>=19.3b0"]},
     include_package_data=True,
 )


### PR DESCRIPTION
* Replace import of `BaseHTTPServer` with its py3 version `http.server`
* Replace import of `urlparse` with its py3 version `urllib.parse`

Paired with https://github.com/matrix-org/sydent/pull/239