### PR TITLE
Fix expected error code when storing an invite

### DIFF
--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -157,4 +157,4 @@ class BaseApiTest(object):
                 "sender": "@sender:fake.test",
             }
         )
-        self.assertEquals(body["errcode"], "THREEPID_IN_USE")
+        self.assertEquals(body["errcode"], "M_THREEPID_IN_USE")


### PR DESCRIPTION
Use `M_THREEPID_IN_USE` when the 3PID is already associated with a MXID instead of `THREEPID_IN_USE`.

Paired with https://github.com/matrix-org/sydent/pull/258