### PR TITLE
fix fake test usernames so v2 tests can run

### DIFF
--- a/matrix_is_tester/base_api_test.py
+++ b/matrix_is_tester/base_api_test.py
@@ -83,7 +83,7 @@ class BaseApiTest(object):
         # get the mail so we don't leave it in the queue
         self.mailSink.get_mail()
         body = self.api.bind_email(
-            req_code_body["sid"], "sekrit", "@commonapitests:fake.test"
+            req_code_body["sid"], "sekrit", "@commonapitests:127.0.0.1:4490"
         )
         self.assertEquals(body["errcode"], "M_SESSION_NOT_VALIDATED")
 
@@ -112,7 +112,7 @@ class BaseApiTest(object):
                 "medium": "email",
                 "address": "ian@fake.test",
                 "room_id": "$aroom:fake.test",
-                "sender": "@sender:fake.test",
+                "sender": "@commonapitests:127.0.0.1:4490",
                 "room_alias": "#alias:fake.test",
                 "room_avatar_url": "mxc://fake.test/roomavatar",
                 "room_name": "my excellent room",
@@ -154,7 +154,7 @@ class BaseApiTest(object):
                 "medium": "email",
                 "address": "already_here@fake.test",
                 "room_id": "$aroom:fake.test",
-                "sender": "@sender:fake.test",
+                "sender": "@commonapitests:127.0.0.1:4490",
             }
         )
         self.assertEquals(body["errcode"], "M_THREEPID_IN_USE")

--- a/matrix_is_tester/fakehs.py
+++ b/matrix_is_tester/fakehs.py
@@ -33,7 +33,7 @@ def token_for_random_user():
     The token will represent a random user account.
     """
     num = random.randint(0, 2 ** 32)
-    user_id = "@user%d:localhost:4490" % (num,)
+    user_id = "@user%d:127.0.0.1:4490" % (num,)
     return "user:%s" % (base64.b64encode(user_id.encode("UTF-8")).decode("UTF-8"),)
 
 
@@ -105,7 +105,7 @@ def _run_http_server():
     cert_file = os.path.join(os.path.dirname(__file__), "fakehs.pem")
 
     httpd = BaseHTTPServer.HTTPServer(
-        ("localhost", 4490), _FakeHomeserverRequestHandler
+        ("127.0.00.1", 4490), _FakeHomeserverRequestHandler
     )
     httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert_file, server_side=True)
     httpd.serve_forever()
@@ -126,7 +126,7 @@ class FakeHomeserver(object):
         Returns a host, port tuple representing the address on which the fake homeserver
         is listening for requests.
         """
-        return ("localhost", 4490)
+        return ("127.0.0.1", 4490)
 
     def tearDown(self):
         self.process.terminate()

--- a/matrix_is_tester/test_account.py
+++ b/matrix_is_tester/test_account.py
@@ -32,12 +32,12 @@ class AccountTest(unittest.TestCase):
         base_url = get_or_launch_is(False)
         api = IsApi(base_url, "v2", None)
         api.make_account(
-            self.fakeHsAddr, token_for_user("@jimmy_account_test:fake.test")
+            self.fakeHsAddr, token_for_user("@jimmy_account_test:127.0.0.1:4490")
         )
 
         body = api.account()
 
-        self.assertEqual(body["user_id"], "@jimmy_account_test:fake.test")
+        self.assertEqual(body["user_id"], "@jimmy_account_test:127.0.0.1:4490")
 
 
 if __name__ == "__main__":

--- a/matrix_is_tester/test_bind_denied.py
+++ b/matrix_is_tester/test_bind_denied.py
@@ -33,11 +33,11 @@ class AccountTest(unittest.TestCase):
     def test_bind_notYourMxid(self):
         base_url = get_or_launch_is(False)
         api = IsApi(base_url, "v2", self.mail_sink)
-        api.make_account(self.fake_hs_addr, token_for_user("@bob:fake.test"))
+        api.make_account(self.fake_hs_addr, token_for_user("@bob:127.0.0.1:4490"))
 
         params = api.request_and_submit_email_code("perfectly_valid_email@nowhere.test")
         body = api.bind_email(
-            params["sid"], params["client_secret"], "@alice:fake.test"
+            params["sid"], params["client_secret"], "@alice:127.0.0.1:4490"
         )
         self.assertEquals(body["errcode"], "M_UNAUTHORIZED")
 

--- a/matrix_is_tester/test_v2.py
+++ b/matrix_is_tester/test_v2.py
@@ -30,18 +30,18 @@ class V2Test(BaseApiTest, unittest.TestCase):
 
         self.fakeHs = get_shared_fake_hs()
         self.api.make_account(
-            self.fakeHs.get_addr(), token_for_user("@commonapitests:fake.test")
+            self.fakeHs.get_addr(), token_for_user("@commonapitests:127.0.0.1:4490")
         )
 
     def test_bind_and_lookup(self):
         params = self.api.request_and_submit_email_code("fakeemail3@nowhere.test")
         body = self.api.bind_email(
-            params["sid"], params["client_secret"], "@commonapitests:fake.test"
+            params["sid"], params["client_secret"], "@commonapitests:127.0.0.1:4490"
         )
 
         self.assertEquals(body["medium"], "email")
         self.assertEquals(body["address"], "fakeemail3@nowhere.test")
-        self.assertEquals(body["mxid"], "@commonapitests:fake.test")
+        self.assertEquals(body["mxid"], "@commonapitests:127.0.0.1:4490")
 
         hash_details = self.api.hash_details()
 
@@ -51,7 +51,7 @@ class V2Test(BaseApiTest, unittest.TestCase):
         )
 
         self.assertIn(lookup_str, body2["mappings"])
-        self.assertEquals(body2["mappings"][lookup_str], "@commonapitests:fake.test")
+        self.assertEquals(body2["mappings"][lookup_str], "@commonapitests:127.0.0.1:4490")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The PR is a fix for this issue: https://github.com/matrix-org/sydent/issues/343
The fake test data in the tester has been updated to be compatible with v2 account authentication. 
Signed-off-by: H.Shay <shaysquared@gmail.com>